### PR TITLE
Use trusted publisher to publish to PyPI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,13 +15,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Publish latest package to PyPI
-        uses: JRubics/poetry-publish@v1.16
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          python_version: '3.9'
-          poetry_version: '==1.4.2' # (PIP version specifier syntax)
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
-          ignore_dev_requirements: 'yes'
+          python-version: 3.9
+
+      - name: Make package
+        run: |
+          python3 -m pip install --upgrade setuptools wheel
+          python3 setup.py sdist bdist_wheel
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.10
+        with:
+          verbose: true
 
   release:
     # This job will only run if the PR has been merged (and not closed without merging).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-svelte-jsoneditor"
-version = "0.1.0"
+version = "0.1.1"
 description = "A widget for django's JSONField using the latest-and-greatest Json Editor"
 authors = ["Tom Clark <tom@octue.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-svelte-jsoneditor"
-version = "0.1.1"
+version = "0.1.0"
 description = "A widget for django's JSONField using the latest-and-greatest Json Editor"
 authors = ["Tom Clark <tom@octue.com>"]
 license = "MIT"


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#6](https://github.com/octue/django-svelte-jsoneditor/pull/6))

### Operations
- Use trusted publisher to publish to PyPI

### Reversions
- Revert version number increase

<!--- END AUTOGENERATED NOTES --->