### PR TITLE
FIX: django 4.x dependency range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [{ include = "django_svelte_jsoneditor" },]
 [tool.poetry.dependencies]
 django = [
     {version = ">=3.1,^4.0", python = "^3.9,<3.10"},
-    {version = ">=3.1,^5.0", python = "^3.10"},
+    { version = ">=3.1 || >=4.0 || ^5.0", python = "^3.10" },
 ]
 python = "^3.9"
 


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#23](https://github.com/octue/django-svelte-jsoneditor/pull/23))

### Fixes
- django 4.x dependency range

<!--- END AUTOGENERATED NOTES --->