### PR TITLE
FIX: crash after edit in text mode

### DIFF
--- a/django_svelte_jsoneditor/templates/django_svelte_jsoneditor/widgets/svelte_jsoneditor.html
+++ b/django_svelte_jsoneditor/templates/django_svelte_jsoneditor/widgets/svelte_jsoneditor.html
@@ -7,16 +7,15 @@
 <script type="module">    
   import { JSONEditor } from '{% static "django_svelte_jsoneditor/js/svelte_jsoneditor.js" %}'
   
-  const json = JSON.parse(document.getElementById('{{ widget.attrs.id }}').value)
-
   const editor = new JSONEditor({
     target: document.getElementById('jsoneditor_{{ widget.attrs.id }}'),
     props: {         
-        content: {
-            json: json || undefined,            
+        content: {   
+          text: document.getElementById('{{ widget.attrs.id }}').value || undefined         
         },        
-        onChange: (updatedContent, previousContent, { contentErrors, patchResult }) => {
-            document.getElementById('{{ widget.attrs.id }}').value = JSON.stringify(updatedContent.json)        
+        onChange: (updatedContent, previousContent, { contentErrors, patchResult }) => {            
+            const value = updatedContent.json ? JSON.stringify(updatedContent.json) : updatedContent.text
+            document.getElementById('{{ widget.attrs.id }}').value = value
         }
     }
   })


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#24](https://github.com/octue/django-svelte-jsoneditor/pull/24))

### Fixes
- crash after edit in text mode

<!--- END AUTOGENERATED NOTES --->