### PR TITLE
Use fixed version of PyPI publishing action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
         run: poetry build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           verbose: true
 


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#38](https://github.com/octue/django-svelte-jsoneditor/pull/38))

### Operations
- Use fixed version of PyPI publishing action

<!--- END AUTOGENERATED NOTES --->